### PR TITLE
Enforce "units" attribute usage and consistency in "JSON" dataset.

### DIFF
--- a/data/camera/canon_s90_380_780_5.json
+++ b/data/camera/canon_s90_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/canon_xti_380_780_5.json
+++ b/data/camera/canon_xti_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/dalsa_380_780_5.json
+++ b/data/camera/dalsa_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/nikon_d200_380_780_5.json
+++ b/data/camera/nikon_d200_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/nikon_d7000_380_780_5.json
+++ b/data/camera/nikon_d7000_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/nikon_d700_380_780_5.json
+++ b/data/camera/nikon_d700_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/nikon_d70_380_780_5.json
+++ b/data/camera/nikon_d70_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/red_mx_380_780_5.json
+++ b/data/camera/red_mx_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/viper_nofilter1_380_780_5.json
+++ b/data/camera/viper_nofilter1_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/data/camera/weiscam_na_380_780_5.json
+++ b/data/camera/weiscam_na_380_780_5.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,

--- a/test/nikon_d200_380_780_5_test.json
+++ b/test/nikon_d200_380_780_5_test.json
@@ -14,7 +14,7 @@
         "license"                : null
     },
     "spectral_data": {
-        "quantity"              : "relative",
+        "units"                 : "relative",
         "reflection_geometry"   : null,
         "transmission_geometry" : null,
         "bandwidth_FWHM"        : null,


### PR DESCRIPTION
References ampas/rawtoaces#26.