### PR TITLE
Updates to usage descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ A help message with a description of all command line options can be obtained by
 	                            (default = 0)
 	  --ss-path <path>        Specify the path to camera sensitivity data
 	                            (default = /usr/local/include/RAWTOACES/data/camera)
-	  --aces-gain float       Set ACES conversion gain factor (default = 6.0)
+	  --headroom float        Set highlight headroom factor (default = 6.0)
 	  --cameras               Show a list of supported cameras/models by LibRaw
 	  --valid-illums          Show a list of illuminants
 	  --valid-cameras         Show a list of cameras/models with available 

--- a/src/usage.h
+++ b/src/usage.h
@@ -93,7 +93,7 @@ void usage(const char *prog)
             // Future feature ? "        3=Use custom matrix <m1r m1g m1b m2r m2g m2b m3r m3g m3b>\n"
             "                            (default = 0)\n"
             "                            (default = /usr/local/include/rawtoaces/data/camera)\n"
-            "  --aces-gain float       Set ACES conversion gain factor (default = 6.0)\n"
+            "  --headroom float        Set highlight headroom factor (default = 6.0)\n"
             "  --cameras               Show a list of supported cameras/models by LibRaw\n"
             "  --valid-illums          Show a list of illuminants\n"
             "  --valid-cameras         Show a list of cameras/models with available "
@@ -148,7 +148,7 @@ void create_key()
     keys["--cameras"] = 'T';
     keys["--wb-method"] = 'R';
     keys["--mat-method"] = 'p';
-    keys["--aces-gain"] = 'M';
+    keys["--headroom"] = 'M';
     keys["--valid-illums"] = 'z';
     keys["--valid-cameras"] = 'Q';
     keys["-c"] = 'c';

--- a/src/usage.h
+++ b/src/usage.h
@@ -96,7 +96,7 @@ void usage(const char *prog)
             "  --headroom float        Set highlight headroom factor (default = 6.0)\n"
             "  --cameras               Show a list of supported cameras/models by LibRaw\n"
             "  --valid-illums          Show a list of illuminants\n"
-            "  --valid-cameras         Show a list of cameras/models with available "
+            "  --valid-cameras         Show a list of cameras/models with available\n"
             "                          spectral sensitivity datasets\n"
             "\n"
             "Raw conversion options:\n"


### PR DESCRIPTION
Minor updates to usage descriptions including updating the "ACES conversion gain factor" to "Highlight headroom factor" to avoid confusion and adding a missing new line control character in valid-cameras description.
