### PR TITLE
Change license type to validate JSON with or without requiring a license

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ The attributes are defined as follows:
         - **type**: `["string", "null"]`
     - `license`
         - **description**: *Required*, usage license of the document, e.g. "CC-BY-NC-ND".
-        - **type**: `"string"`
+        - **type**: `["string", "null"]`
     - `manufacturer`
         - **description**: *Optional*, manufacturer of the device being tested.
         - **type**: `["string", "null"]`


### PR DESCRIPTION
Using the provided schema in the JSON Schema Validator gives a single error. 'License' type is expected to be a string, however a license may not necessarily be issued or needed. Changing the type to String/Null allows for either option.